### PR TITLE
fix-tags-css-style

### DIFF
--- a/demo/colorui.wxss
+++ b/demo/colorui.wxss
@@ -1039,6 +1039,7 @@ button.icon.lg {
 }
 
 .cu-tag+.cu-tag {
+  margin-top: 5rpx;
   margin-left: 10rpx;
 }
 


### PR DESCRIPTION
解决标签超过一行后，上下没有间距。