### PR TITLE
修复 表单 图片上传再次选择数量不变的问题

### DIFF
--- a/demo/pages/component/form/form.js
+++ b/demo/pages/component/form/form.js
@@ -148,8 +148,12 @@ Page({
     })
   },
   ChooseImage() {
+    const {
+      imgList
+    } = this.data;
+
     wx.chooseImage({
-      count: 4, //默认9
+      count: 4 - imgList.length, //默认9
       sizeType: ['original', 'compressed'], //可以指定是原图还是压缩图，默认二者都有
       sourceType: ['album'], //从相册选择
       success: (res) => {


### PR DESCRIPTION
目前表单 图片上传设置为 4 张，第一次选择 2 张退出，再次选择依然可以选择 4 张，修复为 再次选择 = 总数 - 已选数量